### PR TITLE
Fix emulator launch file selection

### DIFF
--- a/TwitchPlaysBot/Launch.py
+++ b/TwitchPlaysBot/Launch.py
@@ -23,10 +23,19 @@ import socket
 from threading import Thread
 import win32com.client, win32api, win32con
 
+
+def find_game_file():
+    """Return the first game file found in the game folder."""
+    for entry in os.listdir('game'):
+        ext = os.path.splitext(entry)[1].lower()
+        if ext not in ('.sav', '.txt'):
+            return entry
+    return None
+
 settings = []
 commands = []
 readbuffer = ""
-GAME = os.listdir('game')[0]
+GAME = find_game_file()
 shell = win32com.client.Dispatch("WScript.Shell")
 
 VK_CODE = {'backspace':0x08,
@@ -201,7 +210,7 @@ def addtofile():
             list_commands.extend([out.lower()])
 
 def startemulator():
-    if os.path.splitext(os.listdir('game')[0])[1] != ".sav":
+    if GAME:
         os.system('"%s\game\%s"' % (os.getcwd(), GAME))
             
 def democracy():


### PR DESCRIPTION
## Summary
- avoid launching placeholder text file
- add helper to find game file

## Testing
- `python3 -m py_compile TwitchPlaysBot/Launch.py`


------
https://chatgpt.com/codex/tasks/task_e_68435742c3108333b9adc5de4b3a189b